### PR TITLE
Tell the webfinger server that we prefer XRD+XML (not JSON)

### DIFF
--- a/ostatus/fetcher.py
+++ b/ostatus/fetcher.py
@@ -17,11 +17,11 @@ class HTTPError(Exception):
     pass
 
 
-def fetch(uri):
+def fetch(uri, headers=None):
     """
     Retrieve the content at uri.
     """
-    response, content = HTTP.request(uri)
+    response, content = HTTP.request(uri, headers=headers)
 
     if response['status'] != '200':
         logging.debug(response, content)

--- a/ostatus/webfinger.py
+++ b/ostatus/webfinger.py
@@ -41,7 +41,7 @@ def finger(identifier):
 
 def _finger(uri):
     """Actual implementation of finger, now that we know where to look"""
-    content = fetch(uri)
+    content = fetch(uri, headers={'Accept': 'application/xrd+xml'})
 
     doc = minidom.parseString(content).documentElement
     return doc.getElementsByTagName('Link')


### PR DESCRIPTION
I don't know if you're still watching this repo, but this is a minor change I had to make to get the tools talking to Mastodon and the current crop of OStatus servers. Basically webfinger now defaults to JSON, so in order to keep things working we send an Accept header specifying that we prefer XML.

This has been tested against Mastodon and Qvitter.